### PR TITLE
Add kmon to subdomains

### DIFF
--- a/domains/kmon
+++ b/domains/kmon
@@ -1,0 +1,1 @@
+orhun.github.io


### PR DESCRIPTION
Hi,

I'd like to add my [project](https://github.com/orhun/kmon) to the subdomains for creating the kmon.cli.rs page for it. I'll enable the GitHub pages and add CNAME to the project repository after this PR is merged.

I hope everything's alright.