### PR TITLE
HTTPS issue with custom domain

### DIFF
--- a/domains/mind
+++ b/domains/mind
@@ -1,1 +1,1 @@
-arijitbasu.in
+sayanarijit.github.io


### PR DESCRIPTION
>  Your site's DNS settings are using a custom subdomain, mind.cli.rs, that's not set up with a correct CNAME record. We recommend you set this CNAME record to point at [YOUR USERNAME].github.io. For more information, see https://help.github.com/articles/setting-up-a-custom-domain-with-github-pages/.