### PR TITLE
Add blocc

### DIFF
--- a/domains/bloc
+++ b/domains/bloc
@@ -1,0 +1,1 @@
+voidentente.github.io


### PR DESCRIPTION
Blocc is a hobbyist work-in-progress Rust rewrite of Minecraft in Bevy.
You can find it here: https://github.com/voidentente/blocc
I will create another pull request to remove the CNAME should the project become abandoned.