### PR TITLE
fix(exilvm): Incorrect DNS record

### DIFF
--- a/domains/exilvm
+++ b/domains/exilvm
@@ -1,1 +1,1 @@
-exilvm.vercel.app
+cname.vercel-dns.com


### PR DESCRIPTION
After the merge, i had the same issue as: #43.

And after further researching and according to to Vercel's documentation, Vercel expects the CNAME DNS record to be `cname.vercel-dns.com`.

Reference: https://vercel.com/docs/concepts/projects/domains/troubleshooting#common-dns-issues

It's also part of the reason why the only working sub-domain out of all Vercel URLs in this repository is the one using the CNAME record:
![image](https://user-images.githubusercontent.com/6927114/229966802-b1fa2843-5af3-4d27-9e07-c7009d1232d3.png)

(Only https://hyperspeed.cli.rs works), the rest don't because they couldn't pass the verification.

So i believe this is the right approach to add a sub-domain to Vercel app.

Sorry for any disturbance. 