### PR TITLE
Delete Nodemore (Invalid DNS Address)

### DIFF
--- a/domains/nodemore
+++ b/domains/nodemore
@@ -1,1 +1,0 @@
-https://github.com/WillKirkmanM/nodemore


### PR DESCRIPTION
For miscellaneous reasons Nodemore did not delete from the previous pull request (https://github.com/zackify/cli.rs/pull/59).
Apologies for inconveniences.

WillKirkmanM
