### PR TITLE
doc: stop calling local registrars shady

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ## something.cli.rs for Rust projects!
 
-The `.rs` domain extension is expensive, and can only be purchased on some really shady providers.
+The `.rs` domain extension is expensive, and being a previously unknown ccTLD
+(of Serbia), can only be purchased on some local registrars even more unknown
+to people not from the country it represents, unlike gTLDs like .com and famous
+ccTLDs like .io.
 
 I purchased `cli.rs` for anyone in the [Rust](https://www.rust-lang.org/) community to use.
 


### PR DESCRIPTION
.rs is previously unknown to people not from Serbia, because domain hackers didn't give it a special meaning besides the country it represents in [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166) alpha-2, like those given to for example .io and .me. ccTLDs are managed by their respective countries, they naturally [accredit local registrars](https://www.rnids.rs/en/registrars/list-accredited-registrars). They aren't shady just because some foreigner doesn't know them well. Unless really popular internationally, respective managing bodies have no need to make them available to those international, popular, "non-shady" registrars.