### PR TITLE
update trippy to point to trippy.rs

### DIFF
--- a/domains/trippy
+++ b/domains/trippy
@@ -1,1 +1,1 @@
-fujiapple852.github.io
+trippy.rs


### PR DESCRIPTION
I finally purchased `trippy.rs`!  

I'd like to keep `trippy.cli.rs` as a CNAME to `trippy.rs`.

Thanks again for maintaining this (free!) service.