### PR TITLE
feat: add rust-stuco.github.io to domains

### DIFF
--- a/domains/stuco
+++ b/domains/stuco
@@ -1,0 +1,1 @@
+rust-stuco.github.io


### PR DESCRIPTION
This is a student-taught course on Rust at Carnegie Mellon University: https://github.com/rust-stuco